### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-##react-todo
+## react-todo
 
 This is a simple todo list application mainly utilizing React JS and the Flux architecture. It's meant as a tutorial or guide for how to build a React JS application.
 
 It uses npm and bower for package management, the default Bootstrap theme, LESS CSS for minor style and positioning adjustments, and finally brunch to build it all up and provide a simple web server. It also uses node's EventEmitter for event notifications as per the Flux architecture.
 
-###Installation
+### Installation
 
 make build
 
-###Run
+### Run
 
 make start
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
